### PR TITLE
feat(other): use addr to listen rather than port only

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,8 +4,8 @@ interface: eth0
 # 汇总时间间隔
 summary_time: 5 
 
-# Web 服务端口
-port: 8080 
+# Web 服务地址
+addr: ":8080"
 
 # 启用 Web 服务
 enable: true 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,9 @@ func (cm *ConfigManager) LoadConfig() error {
 	if config.Interface == "" {
 		config.Interface = utils.GetDefaultInterface()
 	}
+	if !utils.CheckAddr(config.Addr) {
+		return fmt.Errorf("addr 格式错误")
+	}
 	cm.Config = &config
 	return nil
 }

--- a/internal/interfaces/interfaces.go
+++ b/internal/interfaces/interfaces.go
@@ -11,7 +11,7 @@ import (
 type WebSocketServer interface {
 	BroadcastSummary(summary interface{})
 	BroadcastBlackEvent(key string)
-	Start(port int)
+	Start(addr string)
 	HandleWebSocket(w http.ResponseWriter, r *http.Request)
 	Shutdown() error
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -22,7 +22,7 @@ type ConfigBlack struct {
 type Config struct {
 	Interface      string      `json:"interface" yaml:"interface"`
 	SummaryTime    int         `json:"summary_time" yaml:"summary_time"`
-	Port           int         `json:"port" yaml:"port"`
+	Addr           string      `json:"addr" yaml:"addr"`
 	Enable         bool        `json:"enable" yaml:"enable"`
 	Rules          []Rule      `json:"rule" yaml:"rule"`
 	MaxPacketCount int         `json:"max_packet_count" yaml:"max_packet_count"`

--- a/internal/utils/validator.go
+++ b/internal/utils/validator.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"net"
+	"strconv"
+)
+
+// CheckAddr check addr is valid or not, only support some common formats rather than
+// use net.Dial to check due to domain is not allowed
+func CheckAddr(addr string) bool {
+	ip, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	// if port is not numeric, or not in the range of 0-65535, return false
+	if p, err := strconv.Atoi(port); err != nil || p < 0 || p > 65535 {
+		return false
+	}
+	if ip == "" {
+		return true
+	}
+	return net.ParseIP(ip) != nil
+}

--- a/internal/utils/validator_test.go
+++ b/internal/utils/validator_test.go
@@ -1,0 +1,78 @@
+package utils
+
+import "testing"
+
+func Test_checkAddr(t *testing.T) {
+	type args struct {
+		addr string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test checkAddr with valid IPv6 address",
+			args: args{
+				addr: "[2001:db8::1]:8080",
+			},
+			want: true,
+		},
+		{
+			name: "Test checkAddr with invalid port",
+			args: args{
+				addr: "127.0.0.1:99999",
+			},
+			want: false,
+		},
+		{
+			name: "Test checkAddr with non-numeric port",
+			args: args{
+				addr: "127.0.0.1:port",
+			},
+			want: false,
+		},
+		{
+			name: "Test checkAddr with missing port",
+			args: args{
+				addr: "127.0.0.1:",
+			},
+			want: false,
+		},
+		{
+			name: "Test checkAddr with empty address",
+			args: args{
+				addr: "",
+			},
+			want: false,
+		},
+		{
+			name: "Test checkAddr with only empty ip and port",
+			args: args{
+				addr: ":",
+			},
+			want: false,
+		},
+		{
+			name: "Test checkAddr with only port",
+			args: args{
+				addr: ":8080",
+			},
+			want: true,
+		},
+		{
+			name: "Test checkAddr with valid address and port 0",
+			args: args{
+				addr: "127.0.0.1:0",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CheckAddr(tt.args.addr); got != tt.want {
+				t.Errorf("checkAddr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/websocket/websocket.go
+++ b/internal/websocket/websocket.go
@@ -45,7 +45,7 @@ func NewWebSocketServer(fs http.FileSystem) *WebSocketServer {
 	}
 }
 
-func (s *WebSocketServer) Start(port int) {
+func (s *WebSocketServer) Start(addr string) {
 	go s.run()
 
 	s.mux.HandleFunc("/ws", s.HandleWebSocket)
@@ -55,11 +55,11 @@ func (s *WebSocketServer) Start(port int) {
 	}
 
 	s.server = &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
+		Addr:    addr,
 		Handler: s.mux,
 	}
 
-	log.Printf("Starting WebSocket server on port %d", port)
+	log.Printf("Starting WebSocket server on addr %s", addr)
 	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("Failed to start WebSocket server: %v", err)
 	}


### PR DESCRIPTION
## Pull Request Guidelines

- Commit info should be formatted as `type(scope): info about commit`. (e.g. `fix(xdp): fix the memory leak issue in the XDP program.`)

  1. type: type must be one of [build, chore, docs, feat, fix, perf, refactor, revert, release, test, improvement].

  2. scope: scope must be one of [ebpf, usercomm, dataproc, frontend, ui, docs, build, deploy, other].

  3. header: header must not be longer than 72 characters.

- Make sure that running `go build` outputs the correct files.

- Rebase before creating a PR to keep commit history clear.

- Make sure PRs are created to `dev` branch instead of `main` branch.

- If your PR fixes a bug, please provide a description about the related bug.

## Description

The server of this firewall only supports listening on the port specified in the config file. I think we can use the `addr` config item to replace it, allowing the server to listen on other IP addresses (e.g., 127.0.0.1 or the IP of another network interface).